### PR TITLE
Resolved issue where service provider did not dispose correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Provides Dependency Injection (DI) for Inversion of Control (IoC) between classe
 
 ## Samples
 
-[Dependency Injection Sample](https://github.com/nanoframework/Samples/tree/main/samples/DependencyInjection)
+[Dependency Injection Samples](https://github.com/nanoframework/Samples/tree/main/samples/DependencyInjection)
 
 [Dependency Injection Unit Tests](https://github.com/nanoframework/nanoFramework.DependencyInjection/tree/main/tests)
 

--- a/nanoFramework.DependencyInjection/DependencyInjection/ServiceDescriptor.cs
+++ b/nanoFramework.DependencyInjection/DependencyInjection/ServiceDescriptor.cs
@@ -119,7 +119,7 @@ namespace nanoFramework.DependencyInjection
                 return ImplementationInstance.GetType();
             }
 
-            Debug.Assert(false, "ImplementationType, ImplementationInstance or ImplementationFactory must be non null");
+            Debug.Assert(false, "ImplementationType and ImplementationInstance must be non null");
 
             return null;
         }

--- a/nanoFramework.DependencyInjection/DependencyInjection/ServiceProvider.cs
+++ b/nanoFramework.DependencyInjection/DependencyInjection/ServiceProvider.cs
@@ -14,6 +14,7 @@ namespace nanoFramework.DependencyInjection
     /// <exception cref="AggregateException">Some services are not able to be constructed.</exception>
     public sealed class ServiceProvider : IServiceProvider, IDisposable
     {
+        private bool _disposed;
         internal ServiceProviderEngine _engine;
 
         internal ServiceProvider(IServiceCollection services, ServiceProviderOptions options)
@@ -59,18 +60,34 @@ namespace nanoFramework.DependencyInjection
         /// <inheritdoc/>
         public object GetService(Type serviceType)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException();
+            }
+
             return _engine.GetService(serviceType);
         }
 
         /// <inheritdoc/>
         public object[] GetService(Type[] serviceType)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException();
+            }
+
             return _engine.GetService(serviceType);
         }
 
         /// <inheritdoc/>
         public void Dispose()
         {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
             _engine.DisposeServices();
         }
 

--- a/nanoFramework.DependencyInjection/DependencyInjection/ServiceProviderEngine.cs
+++ b/nanoFramework.DependencyInjection/DependencyInjection/ServiceProviderEngine.cs
@@ -36,16 +36,11 @@ namespace nanoFramework.DependencyInjection
         /// </summary>
         internal void DisposeServices()
         {
-            foreach (ServiceDescriptor descriptor in Services)
+            for (int i = Services.Count - 1; i >= 0; i--)
             {
-                if (descriptor.ServiceType == typeof(IServiceProvider))
+                if (Services[i].ImplementationInstance is IDisposable disposable)
                 {
-                    continue;
-                }
-
-                if (descriptor.ImplementationInstance is IDisposable instance)
-                {
-                    instance.Dispose();
+                    disposable.Dispose();
                 }
             }
         }
@@ -192,7 +187,7 @@ namespace nanoFramework.DependencyInjection
 
                         if (service == null)
                         {
-                            throw new InvalidOperationException();
+                            throw new InvalidOperationException($"'{implementationType}'->'{parameterType}'.");
                         }
 
                         types[index] = parameterType;

--- a/tests/DependencyInjectionTests.cs
+++ b/tests/DependencyInjectionTests.cs
@@ -227,6 +227,20 @@ namespace nanoFramework.DependencyInjection.UnitTests
         }
 
         [TestMethod]
+        public void SelfResolveAndDisposeThrowsObjectDisposedException()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddSingleton(typeof(IFakeService), typeof(FakeService))
+                .BuildServiceProvider();
+
+            serviceProvider.Dispose();
+
+            Assert.Throws(typeof(ObjectDisposedException),
+                () => serviceProvider.GetService(typeof(IServiceProvider)));
+        }
+
+
+        [TestMethod]
         public void SafelyDisposeNestedProviderReferences()
         {
             var serviceProvider = new ServiceCollection()
@@ -236,7 +250,7 @@ namespace nanoFramework.DependencyInjection.UnitTests
             var service = (IDisposable)serviceProvider.GetService(typeof(ClassWithNestedReferencesToProvider));
 
             Assert.NotNull(service);
-            //service.Dispose();  //TODO: Not working throwing memory error 
+            service.Dispose();
         }
 
 


### PR DESCRIPTION
## Description
* The service provider object was not disposing correctly and end user feedback limited.
* Minor changes to the readme. 

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
* Added a test case to the project.

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
