### PR TITLE
Implemented IServiceProviderIsService 

### DIFF
--- a/nanoFramework.DependencyInjection/DependencyInjection/ServiceProvider.cs
+++ b/nanoFramework.DependencyInjection/DependencyInjection/ServiceProvider.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections;
-using nanoFramework.DependencyInjection.System;
 
 namespace nanoFramework.DependencyInjection
 {

--- a/nanoFramework.DependencyInjection/DependencyInjection/ServiceProviderEngine.cs
+++ b/nanoFramework.DependencyInjection/DependencyInjection/ServiceProviderEngine.cs
@@ -121,6 +121,13 @@ namespace nanoFramework.DependencyInjection
             return array.Length != 0 ? array : new object[0];
         }
 
+        /// <summary>
+        /// Gets the <see cref="ServiceDescriptor"/> that have been registered for the specified type.
+        /// </summary>
+        /// <param name="serviceType">An object that specifies the type of service object to get.</param>
+        /// <param name="scopeServices">Services collection from current scope.</param>
+        /// <returns>A list of <see cref="ServiceDescriptor"/> that have been registered for the specified type.</returns>
+        /// <exception cref="InvalidOperationException">If <see cref="ServiceProviderOptions.ValidateScopes"/> is true and <see cref="scopeServices"/> is null.</exception>
         private ServiceDescriptor[] GetServiceDescriptors(Type serviceType, IServiceCollection scopeServices = null)
         {
             var descriptors = new ArrayList();

--- a/nanoFramework.DependencyInjection/DependencyInjection/ServiceProviderEngine.cs
+++ b/nanoFramework.DependencyInjection/DependencyInjection/ServiceProviderEngine.cs
@@ -149,16 +149,15 @@ namespace nanoFramework.DependencyInjection
                 switch (descriptor.Lifetime)
                 {
                     case ServiceLifetime.Singleton:
-                        descriptors.Add(descriptor);
-                        break;
-
                     case ServiceLifetime.Transient:
                         descriptors.Add(descriptor);
                         break;
 
                     case ServiceLifetime.Scoped:
                         if (scopeServices == null && Options.ValidateScopes)
+                        {
                             throw new InvalidOperationException();
+                        }
                         break;
                 }
             }
@@ -203,7 +202,9 @@ namespace nanoFramework.DependencyInjection
 
                     case ServiceLifetime.Scoped:
                         if (scopeServices == null && Options.ValidateScopes)
+                        {
                             throw new InvalidOperationException();
+                        }
                         break;
                 }
             }

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ActivatorUtilities.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ActivatorUtilities.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Reflection;
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Helper code for the various activator services.

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/IServiceCollection.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/IServiceCollection.cs
@@ -5,7 +5,7 @@
 
 using System.Collections;
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Default implementation of IServiceCollection.

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/IServiceProviderIsService.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/IServiceProviderIsService.cs
@@ -1,4 +1,6 @@
-﻿namespace System
+﻿using System;
+
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Optional service used to determine if the specified type is available from the <see cref="IServiceProvider"/>.

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/IServiceScope.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/IServiceScope.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Defines scope for <see cref="IServiceProvider"/>.

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceCollection.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceCollection.cs
@@ -5,15 +5,15 @@
 
 using System.Collections;
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Default implementation of <see cref="IServiceCollection"/>.
     /// </summary>
     public class ServiceCollection : IServiceCollection
     {
-        private static readonly object _syncLock = new object();
-        private readonly ArrayList _descriptors = new ArrayList();
+        private static readonly object _syncLock = new();
+        private readonly ArrayList _descriptors = new();
 
         /// <inheritdoc/>
         public bool IsReadOnly => false;

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceCollectionContainerBuilderExtensions.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceCollectionContainerBuilderExtensions.cs
@@ -3,7 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Extension methods for building a <see cref="ServiceProvider"/> from an <see cref="IServiceCollection"/>.
@@ -17,7 +17,7 @@ namespace nanoFramework.DependencyInjection
         /// <returns>The <see cref="ServiceProvider"/>.</returns>
         public static ServiceProvider BuildServiceProvider(this IServiceCollection services)
         {
-            return BuildServiceProvider(services, ServiceProviderOptions.Default);
+            return services.BuildServiceProvider(ServiceProviderOptions.Default);
         }
 
         /// <summary>

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceCollectionServiceExtensions.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceCollectionServiceExtensions.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Collections;
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Extensions for <see cref="IServiceCollection"/>.

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceDescriptor.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceDescriptor.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Diagnostics;
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Describes a service with its service type, implementation, and lifetime.

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceLifetime.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceLifetime.cs
@@ -3,7 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Specifies the lifetime of a service in an <see cref="IServiceCollection"/>.

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceProvider.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceProvider.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Collections;
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// The default <see cref="IServiceProvider"/>.

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceProviderEngine.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceProviderEngine.cs
@@ -7,7 +7,7 @@ using System;
 using System.Reflection;
 using System.Collections;
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Defines an engine for managing <see cref="IServiceCollection"/> services that provides custom support to other objects.

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceProviderEngineScope.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceProviderEngineScope.cs
@@ -5,10 +5,10 @@
 
 using System;
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
-    /// The <see cref="System.IDisposable.Dispose"/> method ends the scope lifetime. Once Dispose
+    /// The <see cref="IDisposable.Dispose"/> method ends the scope lifetime. Once Dispose
     /// is called, any scoped services that have been resolved from
     /// <see cref="IServiceProvider"/> will be disposed.
     /// </summary>
@@ -22,7 +22,7 @@ namespace nanoFramework.DependencyInjection
         /// The root service provider used to resolve dependencies from the scope.
         /// </summary>
         internal ServiceProvider RootProvider { get; }
-        
+
         /// <summary>
         /// Creates instance of <see cref="ServiceProviderEngineScope"/>.
         /// </summary>
@@ -75,7 +75,7 @@ namespace nanoFramework.DependencyInjection
                 return;
             }
 
-            _disposed = true; 
+            _disposed = true;
             DisposeServices();
         }
 

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceProviderOptions.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceProviderOptions.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Options for configuring various behaviors of the default <see cref="IServiceProvider"/> implementation.

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceProviderServiceExtensions.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceProviderServiceExtensions.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Extension methods for getting services from an <see cref="IServiceProvider" />.

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceScope.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/ServiceScope.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Diagnostics;
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// An <see cref="IServiceScope" /> implementation that implements <see cref="IDisposable" />.

--- a/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/TypeExtensions.cs
+++ b/nanoFramework.DependencyInjection/Microsoft/Extensions/DependencyInjection/TypeExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections;
 
-namespace nanoFramework.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Contains extension methods for <see cref="Type"/>.

--- a/nanoFramework.DependencyInjection/Properties/AssemblyInfo.cs
+++ b/nanoFramework.DependencyInjection/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/nanoFramework.DependencyInjection/nanoFramework.DependencyInjection.nfproj
+++ b/nanoFramework.DependencyInjection/nanoFramework.DependencyInjection.nfproj
@@ -13,7 +13,6 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
-    <RootNamespace>nanoFramework.DependencyInjection</RootNamespace>
     <AssemblyName>nanoFramework.DependencyInjection</AssemblyName>
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
     <NF_IsCoreLibrary>True</NF_IsCoreLibrary>
@@ -30,26 +29,26 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Compile Include="DependencyInjection\ActivatorUtilities.cs" />
-    <Compile Include="DependencyInjection\IServiceCollection.cs" />
-    <Compile Include="DependencyInjection\ServiceScope.cs" />
-    <Compile Include="DependencyInjection\IServiceScope.cs" />
-    <Compile Include="DependencyInjection\ServiceProviderEngine.cs" />
-    <Compile Include="DependencyInjection\ServiceProviderEngineScope.cs" />
-    <Compile Include="DependencyInjection\TypeExtensions.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\ActivatorUtilities.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\IServiceCollection.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\ServiceScope.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\IServiceScope.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\ServiceProviderEngine.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\ServiceProviderEngineScope.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\TypeExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="DependencyInjection\ServiceCollection.cs" />
-    <Compile Include="DependencyInjection\ServiceCollectionContainerBuilderExtensions.cs" />
-    <Compile Include="DependencyInjection\ServiceCollectionServiceExtensions.cs" />
-    <Compile Include="DependencyInjection\ServiceDescriptor.cs" />
-    <Compile Include="DependencyInjection\ServiceLifetime.cs" />
-    <Compile Include="DependencyInjection\ServiceProvider.cs" />
-    <Compile Include="DependencyInjection\ServiceProviderOptions.cs" />
-    <Compile Include="DependencyInjection\ServiceProviderServiceExtensions.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\ServiceCollection.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\ServiceCollectionContainerBuilderExtensions.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\ServiceCollectionServiceExtensions.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\ServiceDescriptor.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\ServiceLifetime.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\ServiceProvider.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\ServiceProviderOptions.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\ServiceProviderServiceExtensions.cs" />
     <Compile Include="System\Activator.cs" />
     <Compile Include="System\AggregateException.cs" />
     <Compile Include="System\IServiceProvider.cs" />
-    <Compile Include="System\IServiceProviderIsService.cs" />
+    <Compile Include="Microsoft\Extensions\DependencyInjection\IServiceProviderIsService.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />

--- a/tests/ActivatorUtilitiesTests.cs
+++ b/tests/ActivatorUtilitiesTests.cs
@@ -6,6 +6,7 @@
 using System;
 using nanoFramework.TestFramework;
 using nanoFramework.DependencyInjection.UnitTests.Fakes;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace nanoFramework.DependencyInjection.UnitTests
 {

--- a/tests/DependencyInjectionTests.cs
+++ b/tests/DependencyInjectionTests.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.Extensions.DependencyInjection;
 using nanoFramework.DependencyInjection.UnitTests.Fakes;
 using nanoFramework.TestFramework;
 using System;

--- a/tests/Fakes/FakeObject.cs
+++ b/tests/Fakes/FakeObject.cs
@@ -3,8 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System;
-
 namespace nanoFramework.DependencyInjection.UnitTests.Fakes
 {
     public class FakeObject : IFakeObject

--- a/tests/Fakes/IRootService.cs
+++ b/tests/Fakes/IRootService.cs
@@ -3,8 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System;
-
 namespace nanoFramework.DependencyInjection.UnitTests.Fakes
 {
     internal interface IRootService

--- a/tests/Fakes/IService1.cs
+++ b/tests/Fakes/IService1.cs
@@ -3,8 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System;
-
 namespace nanoFramework.DependencyInjection.UnitTests.Fakes
 {
     internal interface IService1

--- a/tests/Fakes/IService2.cs
+++ b/tests/Fakes/IService2.cs
@@ -3,8 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System;
-
 namespace nanoFramework.DependencyInjection.UnitTests.Fakes
 {
     internal interface IService2

--- a/tests/Fakes/IService3.cs
+++ b/tests/Fakes/IService3.cs
@@ -3,8 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System;
-
 namespace nanoFramework.DependencyInjection.UnitTests.Fakes
 {
     internal interface IService3

--- a/tests/Fakes/InstanceCountServices/SingletonInstanceCountService.cs
+++ b/tests/Fakes/InstanceCountServices/SingletonInstanceCountService.cs
@@ -1,0 +1,27 @@
+﻿namespace nanoFramework.DependencyInjection.UnitTests.Fakes.InstanceCountServices
+{
+    internal interface ISingletonInstanceCountService
+    {
+        int Id { get; }
+    }
+
+    internal class SingletonInstanceCountService : ISingletonInstanceCountService
+    {
+        private readonly ITransientInstanceCountService _transientInstanceCountService;
+        private readonly object _syncLock = new();
+
+        public SingletonInstanceCountService(ITransientInstanceCountService transientInstanceCountService)
+        {
+            _transientInstanceCountService = transientInstanceCountService;
+
+            lock (_syncLock)
+            {
+                InstanceCount += 1;
+                Id = InstanceCount;
+            }
+        }
+
+        public int Id { get; }
+        public static int InstanceCount { get; set; }
+    }
+}

--- a/tests/Fakes/InstanceCountServices/TransientInstanceCountService.cs
+++ b/tests/Fakes/InstanceCountServices/TransientInstanceCountService.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace nanoFramework.DependencyInjection.UnitTests.Fakes.InstanceCountServices
+﻿namespace nanoFramework.DependencyInjection.UnitTests.Fakes.InstanceCountServices
 {
     internal interface ITransientInstanceCountService
     {

--- a/tests/Fakes/InstanceCountServices/TransientInstanceCountService.cs
+++ b/tests/Fakes/InstanceCountServices/TransientInstanceCountService.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace nanoFramework.DependencyInjection.UnitTests.Fakes.InstanceCountServices
+{
+    internal interface ITransientInstanceCountService
+    {
+        int Id { get; }
+    }
+
+    internal class TransientInstanceCountService : ITransientInstanceCountService
+    {
+        private readonly object _syncLock = new();
+
+        public TransientInstanceCountService()
+        {
+            lock (_syncLock)
+            {
+                InstanceCount += 1;
+                Id = InstanceCount;
+            }
+        }
+
+        public int Id { get; }
+        public static int InstanceCount { get; set; }
+    }
+}

--- a/tests/Fakes/PocoClass.cs
+++ b/tests/Fakes/PocoClass.cs
@@ -3,8 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System;
-
 namespace nanoFramework.DependencyInjection.UnitTests.Fakes
 {
     public class PocoClass

--- a/tests/Fakes/Service1.cs
+++ b/tests/Fakes/Service1.cs
@@ -3,8 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System;
-
 namespace nanoFramework.DependencyInjection.UnitTests.Fakes
 {
     internal class Service1 : IService1

--- a/tests/Fakes/Service3.cs
+++ b/tests/Fakes/Service3.cs
@@ -3,8 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System;
-
 namespace nanoFramework.DependencyInjection.UnitTests.Fakes
 {
     internal class Service3 : IService3

--- a/tests/Fakes/StructFakeService.cs
+++ b/tests/Fakes/StructFakeService.cs
@@ -3,8 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using System;
-
 namespace nanoFramework.DependencyInjection.UnitTests.Fakes
 {
     public struct StructFakeService : IStructFakeService

--- a/tests/Properties/AssemblyInfo.cs
+++ b/tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/tests/ServiceCollectionTests.cs
+++ b/tests/ServiceCollectionTests.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.Extensions.DependencyInjection;
 using nanoFramework.DependencyInjection.UnitTests.Fakes;
 using nanoFramework.TestFramework;
 using System;

--- a/tests/ServiceProviderExtensionsTests.cs
+++ b/tests/ServiceProviderExtensionsTests.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.Extensions.DependencyInjection;
 using nanoFramework.TestFramework;
 using System;
 using System.Collections;

--- a/tests/ServiceProviderTests.cs
+++ b/tests/ServiceProviderTests.cs
@@ -1,4 +1,5 @@
-﻿using nanoFramework.TestFramework;
+﻿using Microsoft.Extensions.DependencyInjection;
+using nanoFramework.TestFramework;
 using nanoFramework.DependencyInjection.UnitTests.Fakes.InstanceCountServices;
 
 namespace nanoFramework.DependencyInjection.UnitTests

--- a/tests/ServiceProviderTests.cs
+++ b/tests/ServiceProviderTests.cs
@@ -1,0 +1,34 @@
+﻿using nanoFramework.TestFramework;
+using nanoFramework.DependencyInjection.UnitTests.Fakes.InstanceCountServices;
+
+namespace nanoFramework.DependencyInjection.UnitTests
+{
+    [TestClass]
+    public class ServiceProviderTests
+    {
+        [Cleanup]
+        public void Cleanup()
+        {
+            SingletonInstanceCountService.InstanceCount = 0;
+            TransientInstanceCountService.InstanceCount = 0;
+        }
+
+        [TestMethod]
+        public void GetService_should_only_create_a_single_instance_of_transient_dependencies()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton(typeof(ISingletonInstanceCountService), typeof(SingletonInstanceCountService));
+            serviceCollection.AddTransient(typeof(ITransientInstanceCountService), typeof(TransientInstanceCountService));
+
+            var sut = serviceCollection.BuildServiceProvider();
+
+            // Act
+            var service = (ISingletonInstanceCountService) sut.GetRequiredService(typeof(ISingletonInstanceCountService));
+
+            // Assert
+            Assert.AreEqual(1, SingletonInstanceCountService.InstanceCount);
+            Assert.AreEqual(1, TransientInstanceCountService.InstanceCount);
+        }
+    }
+}

--- a/tests/nanoFramework.DependencyInjection.UnitTests.nfproj
+++ b/tests/nanoFramework.DependencyInjection.UnitTests.nfproj
@@ -31,6 +31,8 @@
     <Compile Include="DependencyInjectionTests.cs" />
     <Compile Include="Fakes\ClassWithMultipleCtors.cs" />
     <Compile Include="Fakes\ClassWithPrimitiveBinding.cs" />
+    <Compile Include="Fakes\InstanceCountServices\SingletonInstanceCountService.cs" />
+    <Compile Include="Fakes\InstanceCountServices\TransientInstanceCountService.cs" />
     <Compile Include="Fakes\CreationCountFakeService.cs" />
     <Compile Include="Fakes\ClassWithThrowingEmptyCtor.cs" />
     <Compile Include="Fakes\ClassWithThrowingCtor.cs" />
@@ -58,6 +60,7 @@
     <Compile Include="Fakes\Service3.cs" />
     <Compile Include="Fakes\FakeTwoMultipleService.cs" />
     <Compile Include="Fakes\StructFakeService.cs" />
+    <Compile Include="ServiceProviderTests.cs" />
     <Compile Include="ServiceProviderExtensionsTests.cs" />
     <Compile Include="ServiceCollectionTests.cs" />
     <Compile Include="AggregateExceptionTests.cs" />

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0",
+  "version": "1.1",
   "assemblyVersion": {
     "precision": "build"
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "2.0",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
## Description
- Added `GetServiceDescriptors(type)` to retrieve registered `ServiceDescriptor`
- Replace `GetService(type)` with call to `GetServiceDescriptors(type)` in `GetParameters(Type implementationType)`
- Bail early in `GetParameters(Type implementationType)` as soon as we find out that we cannot support the current constructor

## Motivation and Context
- Improve performance and don't create throwaway instances of transient services during constructor resolution.
- Fixes nanoFramework/Home#1383.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Unit tests
- On device

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [X] Improvement (non-breaking change that improves a feature, code or algorithm)
- [X] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [X] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [X] I have added new tests to cover my changes.
